### PR TITLE
ClientFromContext should use the statsd.ClientInterface

### DIFF
--- a/datadog/context.go
+++ b/datadog/context.go
@@ -33,11 +33,11 @@ func CreateClient(namespace string, options ...statsd.Option) statsd.ClientInter
 }
 
 // Extract client from context
-func ClientFromContext(ctx context.Context) *statsd.Client {
+func ClientFromContext(ctx context.Context) *statsd.ClientInterface {
 	value := ctx.Value(statsdClient)
 	if value == nil {
 		panic("No statsd client found in context")
 	}
 
-	return value.(*statsd.Client)
+	return value.(*statsd.ClientInterface)
 }

--- a/datadog/context.go
+++ b/datadog/context.go
@@ -33,11 +33,11 @@ func CreateClient(namespace string, options ...statsd.Option) statsd.ClientInter
 }
 
 // Extract client from context
-func ClientFromContext(ctx context.Context) *statsd.ClientInterface {
+func ClientFromContext(ctx context.Context) statsd.ClientInterface {
 	value := ctx.Value(statsdClient)
 	if value == nil {
 		panic("No statsd client found in context")
 	}
 
-	return value.(*statsd.ClientInterface)
+	return value.(statsd.ClientInterface)
 }


### PR DESCRIPTION
Updates ClientFromContext to use statsd.ClientInterface rather than statsd.Client to allow for the no-op datadog testing client